### PR TITLE
feat：重构代码，增加自定义配置

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,51 @@
+
+<div align="center">
+
 ![:astrbot_plugin_help](https://count.getloli.com/@:astrbot_plugin_help?theme=minecraft)
-# Plugin_help
 
-> AstrBot 插件
+# astrbot_plugin_afdian
 
+_✨ [astrbot](https://github.com/AstrBotDevs/AstrBot) 帮助插件 ✨_  
 
-## 更新 & 🐔 使用说明
+[![License](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
+[![Python 3.10+](https://img.shields.io/badge/Python-3.10%2B-blue.svg)](https://www.python.org/)
+[![AstrBot](https://img.shields.io/badge/AstrBot-3.4%2B-orange.svg)](https://github.com/Soulter/AstrBot)
+[![GitHub](https://img.shields.io/badge/作者-Zhalslar-blue)](https://github.com/Zhalslar)
 
-命令`/helps`
-生成图片如下：
+</div>
 
+# astrbot_plugin_help
+
+## 🤝 介绍
+
+查看所有命令，包括插件，返回一张帮助图片
+
+## 📦 安装
+
+- 可以直接在astrbot的插件市场搜索astrbot_plugin_help，点击安装，耐心等待安装完成即可
+- 若是安装失败，可以尝试直接克隆源码：
+
+```bash
+# 克隆仓库到插件目录
+cd /AstrBot/data/plugins
+git clone https://github.com/Zhalslar/astrbot_plugin_help
+
+# 控制台重启AstrBot
+```
+
+## 🐔 使用说明
+
+### 命令表
+
+|  命令    |     说明     |
+|:--------:|:--------------|
+| `/helps` | 生成帮助图, 别名：`帮助``菜单``功能` |
+
+### 示例图
 
 ![7791647af2717a4a933d209a4a1cd722_720](https://github.com/user-attachments/assets/cb29069c-5692-4b02-9747-0efb095c3c0d)
 
-
-> [!TIP]\
-> 后续会将其输出一张精美图片！  √已完成
 # 支持
+
 本插件改自Astrbot默认插件。
 [帮助文档](https://astrbot.app)

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -1,0 +1,19 @@
+{
+    "show_builtin_cmds": {
+        "description": "显示内置插件命令",
+        "type": "bool",
+        "default": false
+    },
+    "custom_cmds": {
+        "description": "自定义的额外命令",
+        "hint": "一些通过正则或者监听器形成的命令无法检测，可通过自定义方式补充，格式为“命令: 一段描述”，分隔符为英文逗号或#",
+        "type": "list",
+        "default": []
+    },
+    "plugin_blacklist": {
+        "description": "插件黑名单",
+        "hint": "填写插件名称(区分大小写)，如：astrbot_plugin_help，黑名单里的插件不显示帮助",
+        "type": "list",
+        "default": []
+    }
+}

--- a/draw.py
+++ b/draw.py
@@ -1,684 +1,539 @@
-# -*- coding: utf-8 -*-
-import textwrap
-from PIL import Image, ImageDraw, ImageFont, ImageOps
 import io
 import os
+import textwrap
+from typing import Dict, List, Tuple, Any
+
 import numpy as np
-import math
+from PIL import Image, ImageDraw, ImageFont
 
 from astrbot.api import logger
-
-# --- Configuration ---
-FONT_PATH_REGULAR = os.path.join(os.path.dirname(__file__), "DouyinSansBold.otf")
-FONT_PATH_BOLD = os.path.join(os.path.dirname(__file__), "DouyinSansBold.otf")
-LOGO_PATH = os.path.join(os.path.dirname(__file__), "astrbot_logo.jpg")
-
-# logger.info(f"字体路径: {FONT_PATH_REGULAR}, {FONT_PATH_BOLD}")
-# logger.info(f"Logo 路径: {LOGO_PATH}")
-
-# --- File Checks ---
-if not os.path.exists(FONT_PATH_REGULAR) or not os.path.exists(FONT_PATH_BOLD): logger.error("错误：字体文件未找到！");
-if not os.path.exists(LOGO_PATH): logger.error(f"错误：Logo 文件 '{LOGO_PATH}' 未找到！");
-
-# --- Style Configuration (Light Theme) ---
-IMG_WIDTH = 800;
-PADDING = 25
-COLOR_BACKGROUND_START = (248, 250, 255);
-COLOR_BACKGROUND_END = (255, 252, 248)
-COLOR_SECTION_HEADER_BG = (240, 242, 248);
-COLOR_CARD_BACKGROUND = (255, 255, 255)
-COLOR_CARD_OUTLINE = (220, 225, 235);
-COLOR_TEXT_HEADER = (0, 40, 100)
-COLOR_TEXT_SUBTITLE = (80, 80, 80);
-COLOR_TEXT_PLUGIN = (0, 60, 130)
-COLOR_TEXT_COMMAND = (10, 70, 140);
-COLOR_TEXT_DESC = (70, 70, 70)
-COLOR_TEXT_FOOTER = (100, 100, 100);
-COLOR_ACCENT = (0, 90, 180)
-COLOR_LOGO_BG_REMOVE = (255, 255, 255);
-LOGO_BG_TOLERANCE = 25
-
-# --- Fonts ---
-try:
-    font_title = ImageFont.truetype(FONT_PATH_BOLD, 36);
-    font_subtitle = ImageFont.truetype(FONT_PATH_REGULAR, 18)
-    font_plugin_header = ImageFont.truetype(FONT_PATH_BOLD, 20);
-    font_command = ImageFont.truetype(FONT_PATH_BOLD, 15)
-    font_desc = ImageFont.truetype(FONT_PATH_REGULAR, 13);
-    font_footer = ImageFont.truetype(FONT_PATH_REGULAR, 12)
-except Exception as e:
-    logger.error(f"加载字体时出错: {e}"); exit()
-
-# --- Layout Metrics ---
-TOP_AREA_HEIGHT = 120;
-LOGO_TARGET_HEIGHT = 50;
-SECTION_HEADER_HEIGHT = 50
-SECTION_MARKER_SIZE = 18;
-SECTION_MARKER_PADDING = (SECTION_HEADER_HEIGHT - SECTION_MARKER_SIZE) // 2
-SECTION_TITLE_LEFT_MARGIN = SECTION_MARKER_PADDING * 2 + SECTION_MARKER_SIZE
-SECTION_SPACING_BELOW_HEADER = 15;
-SECTION_SPACING_AFTER_CARDS = 25
-CARD_PADDING_X = 15;
-CARD_PADDING_Y = 12;
-CARD_SPACING = 12;
-CARD_CORNER_RADIUS = 10
-CARD_INTERNAL_SPACE = 4;
-FOOTER_HEIGHT = 40
-TALL_CARD_DESC_LENGTH_THRESHOLD = 100
-
-# --- Input Data ---
-BUILT_IN_COMMANDS_TEXT = """
-[System]
-/t2i : 开关文本转图片
-/tts : 开关文本转语音
-/sid : 获取会话 ID
-/op : 管理员
-/wl : 白名单
-/dashboard_update : 更新管理面板(op)
-/alter_cmd : 设置指令权限(op)
-
-[大模型]
-/provider : 大模型提供商
-/model : 模型列表
-/ls : 对话列表
-/new : 创建新对话
-/switch 序号 : 切换对话
-/rename 新名字 : 重命名当前对话
-/del : 删除当前会话对话(op)
-/reset : 重置 LLM 会话(op)
-/history : 当前对话的对话记录
-/persona : 人格情景(op)
-/tool ls : 函数工具
-/key : API Key(op)
-/websearch : 网页搜索
-"""
+from astrbot.core.config.astrbot_config import AstrBotConfig
 
 
-# --- Helper Functions ---
-def parse_single_command_list(text_list):
-    # Code from previous correct version
-    commands_list = [];
-    last_command = None;
-    processed_lines = []
-    if isinstance(text_list, str):
-        lines_raw = text_list.strip().splitlines()
-        for line in lines_raw:
-            stripped = line.strip()
-            if not stripped: continue
-            if stripped.startswith('[') and stripped.endswith(']'): continue
-            processed_lines.append(line)
-    elif isinstance(text_list, list):
-        processed_lines = text_list
-    for line in processed_lines:
-        stripped_line = line.strip();
-        if not stripped_line: continue
-        is_continuation = (line.startswith('  ') or line.startswith('\t'))
-        if is_continuation and last_command and commands_list:
-            cmd, desc = commands_list[-1];
-            current_desc = desc if desc is not None else ""
-            prefix = "\n" if not line.startswith((' ', '\t')) else "\n";
-            commands_list[-1] = (cmd, current_desc + prefix + line.lstrip());
-            continue
-        last_command = None;
-        parts = [];
-        sep_found = None
-        if ' : ' in stripped_line:
-            parts = stripped_line.split(' : ', 1); sep_found = ' : '
-        elif ' # ' in stripped_line:
-            parts = stripped_line.split(' # ', 1); sep_found = ' # '
-        elif '#' in stripped_line and not stripped_line.startswith('#'):
-            parts = stripped_line.split('#', 1); sep_found = '#'
-        elif ':' in stripped_line and not stripped_line.startswith(':'):
-            parts = stripped_line.split(':', 1); sep_found = ':'
-        command = None;
-        description = None
-        if len(parts) == 2 and sep_found:
-            cmd_part = parts[0]
-            if cmd_part.startswith('- '):
-                command = cmd_part[2:].strip()
-            else:
-                command = cmd_part.strip()
-            description = parts[1].strip()
-        else:
-            cmd_part = stripped_line
-            if cmd_part.startswith('- '):
-                command = cmd_part[2:].strip()
-            else:
-                command = cmd_part.strip()
-            description = None
-        if command:
-            if description is not None and not description: description = None
-            commands_list.append((command, description));
-            last_command = command
-    cleaned_list = []
-    for cmd, desc in commands_list:
-        # 只取描述的第一行
-        if desc and '\n' in desc:
-            desc = desc.split('\n')[0].strip()
-        cleaned_list.append((cmd, desc.strip() if desc else None))
-    return cleaned_list
+class AstrBotHelpDrawer:
+    # ---------------- 常量区 ----------------
+    FONT_PATH_REGULAR = os.path.join(os.path.dirname(__file__), "DouyinSansBold.otf")
+    FONT_PATH_BOLD = FONT_PATH_REGULAR
+    LOGO_PATH = os.path.join(os.path.dirname(__file__), "astrbot_logo.jpg")
 
+    # 主题色
+    COLOR_BACKGROUND_START = (248, 250, 255)
+    COLOR_BACKGROUND_END = (255, 252, 248)
+    COLOR_SECTION_HEADER_BG = (240, 242, 248)
+    COLOR_CARD_BACKGROUND = (255, 255, 255)
+    COLOR_CARD_OUTLINE = (220, 225, 235)
+    COLOR_TEXT_HEADER = (0, 40, 100)
+    COLOR_TEXT_SUBTITLE = (80, 80, 80)
+    COLOR_TEXT_PLUGIN = (0, 60, 130)
+    COLOR_TEXT_COMMAND = (10, 70, 140)
+    COLOR_TEXT_DESC = (70, 70, 70)
+    COLOR_TEXT_FOOTER = (100, 100, 100)
+    COLOR_ACCENT = (0, 90, 180)
+    COLOR_LOGO_BG_REMOVE = (255, 255, 255)
+    LOGO_BG_TOLERANCE = 25
 
-def parse_plugin_commands_sorted_grouped(plugin_dict):
-    built_in_plugin = None;
-    large_plugins = [];
-    small_plugins = []
-    built_in_commands_list = parse_single_command_list(BUILT_IN_COMMANDS_TEXT)
-    if built_in_commands_list: built_in_plugin = ("内置指令", built_in_commands_list)
-    for plugin_name, command_list_raw in plugin_dict.items():
-        # 移除对 astrbot 开头插件的过滤
-        if plugin_name == "内置指令" or not command_list_raw: continue
-        plugin_commands = parse_single_command_list(command_list_raw)
-        if plugin_commands:
-            count = len(plugin_commands)
-            if count == 1:
-                small_plugins.append((plugin_name, plugin_commands))
-            elif count >= 2:
-                large_plugins.append((plugin_name, plugin_commands))
-    large_plugins.sort(key=lambda item: len(item[1]), reverse=True)
-    grouped_small_plugin = None
-    if small_plugins:
-        all_small_commands = [];
-        [all_small_commands.extend(cmds) for name, cmds in small_plugins]
-        if all_small_commands: grouped_small_plugin = ("简易指令", all_small_commands); logger.info(
-            f"-> 创建 '简易指令' ({len(all_small_commands)} 条)")
-    final_plugin_data = []
-    if built_in_plugin: final_plugin_data.append(built_in_plugin)
-    final_plugin_data.extend(large_plugins)
-    if grouped_small_plugin: final_plugin_data.append(grouped_small_plugin)
-    # print("最终插件绘制顺序:", [p[0] for p in final_plugin_data])
-    return final_plugin_data
+    # 布局尺寸
+    IMG_WIDTH = 800
+    PADDING = 25
+    TOP_AREA_HEIGHT = 120
+    LOGO_TARGET_HEIGHT = 65
+    SECTION_HEADER_HEIGHT = 50
+    SECTION_MARKER_SIZE = 18
+    SECTION_MARKER_PADDING = (SECTION_HEADER_HEIGHT - SECTION_MARKER_SIZE) // 2
+    SECTION_TITLE_LEFT_MARGIN = SECTION_MARKER_PADDING * 2 + SECTION_MARKER_SIZE
+    SECTION_SPACING_BELOW_HEADER = 15
+    SECTION_SPACING_AFTER_CARDS = 25
+    CARD_PADDING_X = 15
+    CARD_PADDING_Y = 12
+    CARD_SPACING = 12
+    CARD_CORNER_RADIUS = 10
+    CARD_INTERNAL_SPACE = 4
+    FOOTER_HEIGHT = 40
+    TALL_CARD_DESC_LENGTH_THRESHOLD = 100
 
+    # 内边距常量
+    CARD_PADDING_TOP = 10
+    CARD_PADDING_BOTTOM = 10
+    NAME_DESC_SPACING = 12
 
-def draw_gradient(draw, width, height, color_start, color_end):
-    for y in range(height): ratio = y / float(height); r = int(
-        color_start[0] * (1 - ratio) + color_end[0] * ratio); g = int(
-        color_start[1] * (1 - ratio) + color_end[1] * ratio); b = int(
-        color_start[2] * (1 - ratio) + color_end[2] * ratio); draw.line([(0, y), (width, y)], fill=(r, g, b))
+    # 内置指令文本
+    BUILT_IN_COMMANDS_TEXT = textwrap.dedent("""
+        [System]
+        /t2i : 开关文本转图片
+        /tts : 开关文本转语音
+        /sid : 获取会话 ID
+        /op : 管理员
+        /wl : 白名单
+        /dashboard_update : 更新管理面板(op)
+        /alter_cmd : 设置指令权限(op)
 
+        [大模型]
+        /provider : 大模型提供商
+        /model : 模型列表
+        /ls : 对话列表
+        /new : 创建新对话
+        /switch 序号 : 切换对话
+        /rename 新名字 : 重命名当前对话
+        /del : 删除当前会话对话(op)
+        /reset : 重置 LLM 会话(op)
+        /history : 当前对话的对话记录
+        /persona : 人格情景(op)
+        /tool ls : 函数工具
+        /key : API Key(op)
+        /websearch : 网页搜索
+    """).strip()
 
-def get_text_metrics(text, font, draw):
-    if not text: return (0, 0, 0, 0), (0, 0)
-    try:
-        bbox = draw.textbbox((0, 0), text, font=font); width = bbox[2] - bbox[0]; height = bbox[3] - bbox[
-            1]; return bbox, (width, height)
-    except AttributeError:
-        width = draw.textlength(text, font=font); metrics = font.getmetrics(); height = metrics[0] + metrics[1] if sum(
-            metrics) > 0 else font.size * 1.2; return (0, 0, width, height), (width, height)
-    except Exception:
-        est_h = font.size * 1.2; est_w = len(text) * font.size * 0.6; return (
-        0, 0, max(1, int(est_w)), max(1, int(est_h))), (max(1, int(est_w)), max(1, int(est_h)))
+    # ---------------- 构造函数 ----------------
+    def __init__(self, config: AstrBotConfig) -> None:
+        self.config = config
+        self._load_fonts()
+        self._load_logo()
 
-
-def draw_rounded_rectangle(draw, xy, radius, fill=None, outline=None, width=1):
-    x1, y1, x2, y2 = xy;
-    if x1 >= x2 or y1 >= y2: return; radius = min(radius, (x2 - x1) // 2, (y2 - y1) // 2)
-    if fill: draw.rectangle((x1 + radius, y1, x2 - radius, y2), fill=fill); draw.rectangle(
-        (x1, y1 + radius, x2, y2 - radius), fill=fill); draw.pieslice((x1, y1, x1 + 2 * radius, y1 + 2 * radius), 180,
-                                                                      270, fill=fill); draw.pieslice(
-        (x2 - 2 * radius, y1, x2, y1 + 2 * radius), 270, 360, fill=fill); draw.pieslice(
-        (x1, y2 - 2 * radius, x1 + 2 * radius, y2), 90, 180, fill=fill); draw.pieslice(
-        (x2 - 2 * radius, y2 - 2 * radius, x2, y2), 0, 90, fill=fill)
-    if outline and width > 0: draw.arc((x1, y1, x1 + 2 * radius, y1 + 2 * radius), 180, 270, fill=outline,
-                                       width=width); draw.arc((x2 - 2 * radius, y1, x2, y1 + 2 * radius), 270, 360,
-                                                              fill=outline, width=width); draw.arc(
-        (x1, y2 - 2 * radius, x1 + 2 * radius, y2), 90, 180, fill=outline, width=width); draw.arc(
-        (x2 - 2 * radius, y2 - 2 * radius, x2, y2), 0, 90, fill=outline, width=width); draw.line(
-        [(x1 + radius, y1), (x2 - radius, y1)], fill=outline, width=width); draw.line(
-        [(x1 + radius, y2), (x2 - radius, y2)], fill=outline, width=width); draw.line(
-        [(x1, y1 + radius), (x1, y2 - radius)], fill=outline, width=width); draw.line(
-        [(x2, y1 + radius), (x2, y2 - radius)], fill=outline, width=width)
-
-
-def calculate_card_content_height(command, description, card_inner_width, draw):
-    cmd_h = 0;
-    desc_h = 0;
-    space = 0;
-    card_inner_width = max(1, card_inner_width)
-    if command: _bbox, (_w, cmd_h) = get_text_metrics(command, font_command, draw); cmd_h = max(1, cmd_h)
-    if description:
-        # 只取描述的第一行
-        if '\n' in description:
-            description = description.split('\n')[0].strip()
-
-        avg_char_width_bbox, (avg_w, avg_h) = get_text_metrics("A", font_desc, draw);
-        avg_char_width = avg_w if avg_w > 0 else font_desc.size * 0.6
-        wrap_width_chars = 10
-        if avg_char_width > 0: wrap_width_chars = max(10, int(card_inner_width / avg_char_width * 0.95))
-        desc_lines = textwrap.wrap(description, width=wrap_width_chars, replace_whitespace=False, drop_whitespace=False,
-                                   break_long_words=True)
-        desc_internal_spacing = 1
-        for i, line in enumerate(desc_lines):
-            _bbox_line, (_w_line, line_h) = get_text_metrics(line, font_desc, draw);
-            desc_h += max(1, line_h)
-            if i < len(desc_lines) - 1: desc_h += desc_internal_spacing
-    if cmd_h > 0 and desc_h > 0: space = CARD_INTERNAL_SPACE
-    total_content_height = cmd_h + space + desc_h
-    return total_content_height
-
-
-# --- Logo Loading ---
-try:
-    logo_img_original = Image.open(LOGO_PATH).convert("RGBA");
-    img_data = np.array(logo_img_original);
-    r, g, b, a = img_data.T
-    white_areas = (r >= COLOR_LOGO_BG_REMOVE[0] - LOGO_BG_TOLERANCE) & (
-                g >= COLOR_LOGO_BG_REMOVE[1] - LOGO_BG_TOLERANCE) & (
-                              b >= COLOR_LOGO_BG_REMOVE[2] - LOGO_BG_TOLERANCE) & (a > 128)
-    img_data[..., -1][white_areas.T] = 0;
-    logo_transparent_bg = Image.fromarray(img_data);
-    original_width, original_height = logo_transparent_bg.size;
-    aspect_ratio = original_width / original_height
-    new_logo_width = int(LOGO_TARGET_HEIGHT * aspect_ratio);
-    resized_logo = logo_transparent_bg.resize((new_logo_width, LOGO_TARGET_HEIGHT), Image.Resampling.LANCZOS);
-    # print(f"Logo 调整大小为 {resized_logo.size}")
-except Exception as e:
-    logger.warning(f"加载或处理 Logo 时出错: {e}"); resized_logo = None
-
-# --- Main Execution ---
-def draw_help_image(command_data):
-    plugins_data = parse_plugin_commands_sorted_grouped(command_data)
-    if not plugins_data: logger.warning("错误：没有解析到任何有效的插件或命令。"); exit()
-    draw_temp = ImageDraw.Draw(Image.new('RGB', (1, 1)))
-    # print("开始计算图片高度...")
-    current_y = PADDING + TOP_AREA_HEIGHT
-    available_width_for_cards = IMG_WIDTH - PADDING * 2
-
-    # --- Height Calculation (Pass 1) ---
-    for plugin_index, (plugin_name, commands) in enumerate(plugins_data):
-        current_y += SECTION_HEADER_HEIGHT + SECTION_SPACING_BELOW_HEADER
-        cards_info = []  # 存储每个卡片的信息，用于更智能地布局
-
-        # 预计算每个卡片的宽度和高度
-        if commands:
-            # 基础卡片设置
-            max_cards_per_row = 4  # 每行最多放置的卡片数
-            std_card_width = (available_width_for_cards - (max_cards_per_row - 1) * CARD_SPACING) / max_cards_per_row
-            std_card_inner_width = max(50, std_card_width - CARD_PADDING_X * 2)
-            double_card_width = min(available_width_for_cards, std_card_width * 2 + CARD_SPACING)
-            double_card_inner_width = max(50, double_card_width - CARD_PADDING_X * 2)
-
-            # 计算每个卡片的尺寸
-            for i, (cmd, desc) in enumerate(commands):
-                # 只取描述的第一行
-                if desc and '\n' in desc:
-                    desc = desc.split('\n')[0].strip()
-
-                is_tall = (desc is not None and len(desc) > TALL_CARD_DESC_LENGTH_THRESHOLD)
-                if is_tall:
-                    card_w = double_card_width
-                    card_inner_w = double_card_inner_width
-                    # 使用双宽卡片
-                    size_category = "double"  # 双宽卡片
-                else:
-                    card_w = std_card_width
-                    card_inner_w = std_card_inner_width
-                    size_category = "standard"  # 标准卡片
-
-                content_h = calculate_card_content_height(cmd, desc, card_inner_w, draw_temp)
-                card_h = content_h + CARD_PADDING_Y * 2
-
-                # 增加描述长度属性
-                desc_length = len(desc) if desc else 0
-
-                cards_info.append({
-                    "index": i,
-                    "cmd": cmd,
-                    "desc": desc,
-                    "desc_length": desc_length,  # 描述长度属性
-                    "width": card_w,
-                    "height": card_h,
-                    "inner_width": card_inner_w,
-                    "category": size_category
-                })
-
-            # 更智能地排序卡片 - 针对更高效的布局
-            # 首先处理双宽卡片，然后用描述长度优先算法处理剩余卡片
-            double_cards = [card for card in cards_info if card["category"] == "double"]
-            standard_cards = [card for card in cards_info if card["category"] == "standard"]
-
-            # 按描述长度排序标准卡片（短的在前面）
-            standard_cards.sort(key=lambda x: x["desc_length"])
-
-            # 把卡片放入行中 - 使用更智能的算法来减少空白
-            rows = []
-            current_row = {"cards": [], "width_used": 0, "max_height": 0}
-
-            # 首先放置所有双宽卡片 - 每个都独占一行
-            for card in double_cards:
-                rows.append({"cards": [card], "width_used": card["width"], "max_height": card["height"]})
-
-            # 然后使用更高效的算法放置标准卡片
-            for card in standard_cards:
-                # 尝试将卡片添加到当前行
-                if current_row["width_used"] + card["width"] + CARD_SPACING <= available_width_for_cards:
-                    # 当前行还有空间
-                    if current_row["width_used"] > 0:  # 如果不是行的第一个卡片，添加间距
-                        current_row["width_used"] += CARD_SPACING
-                    current_row["cards"].append(card)
-                    current_row["width_used"] += card["width"]
-                    current_row["max_height"] = max(current_row["max_height"], card["height"])
-                else:
-                    # 当前行没有足够空间，创建新行
-                    if current_row["cards"]:  # 如果当前行有卡片，保存它
-                        rows.append(current_row)
-                    current_row = {"cards": [card], "width_used": card["width"], "max_height": card["height"]}
-
-            # 添加最后一行（如果有卡片）
-            if current_row["cards"]:
-                rows.append(current_row)
-
-            # 根据行信息计算总高度
-            for row in rows:
-                current_y += row["max_height"] + CARD_SPACING
-
-            # 减去最后一行之后的额外空间
-            current_y -= CARD_SPACING
-
-        current_y += SECTION_SPACING_AFTER_CARDS
-
-    total_height = current_y + FOOTER_HEIGHT
-    total_height = int(math.ceil(total_height))
-    # print(f"计算出的图片高度: {total_height}")
-
-    # --- Pass 2: Create Image and Draw ---
-    img = Image.new('RGB', (IMG_WIDTH, total_height), (255, 255, 255))
-    draw = ImageDraw.Draw(img)
-    draw_gradient(draw, IMG_WIDTH, total_height, COLOR_BACKGROUND_START, COLOR_BACKGROUND_END)
-
-    # --- Draw Top Area ---
-    current_y = PADDING
-    if resized_logo:
-        logo_x = PADDING
-        logo_y = current_y + (TOP_AREA_HEIGHT - PADDING - resized_logo.height) // 2
+    # ---------------- 字体 & Logo ----------------
+    def _load_fonts(self) -> None:
         try:
-            img.paste(resized_logo, (logo_x, logo_y), mask=resized_logo)
+            self.font_title = ImageFont.truetype(self.FONT_PATH_BOLD, 36)
+            self.font_subtitle = ImageFont.truetype(self.FONT_PATH_REGULAR, 18)
+            self.font_plugin_header = ImageFont.truetype(self.FONT_PATH_BOLD, 20)
+            self.font_command = ImageFont.truetype(self.FONT_PATH_BOLD, 15)
+            self.font_desc = ImageFont.truetype(self.FONT_PATH_REGULAR, 13)
+            self.font_footer = ImageFont.truetype(self.FONT_PATH_REGULAR, 12)
         except Exception as e:
-            logger.warning(f"粘贴 Logo 失败 (尝试带透明度): {e}")
-            try:
-                img.paste(resized_logo.convert("RGB"), (logo_x, logo_y))
-                logger.warning("警告: Logo 作为不透明图像粘贴 (因透明度粘贴失败)")
-            except Exception as e2:
-                logger.warning(f"Logo 回退粘贴也失败: {e2}")
-    title_x = PADDING + (resized_logo.width + 20 if resized_logo else 0)
-    _bbox_title, (title_w, title_h) = get_text_metrics("AstrBot 命令帮助", font_title, draw)
-    _bbox_sub, (sub_w, sub_h) = get_text_metrics("可用插件及指令列表", font_subtitle, draw)
-    title_y = current_y + (TOP_AREA_HEIGHT - PADDING - title_h - sub_h - 5) // 2
-    draw.text((title_x, title_y), "AstrBot 命令帮助", font=font_title, fill=COLOR_TEXT_HEADER)
-    draw.text((title_x, title_y + title_h + 5), "可用插件及指令列表", font=font_subtitle, fill=COLOR_TEXT_SUBTITLE)
-    current_y += TOP_AREA_HEIGHT
+            logger.error(f"加载字体时出错: {e}")
+            exit()
 
-    # --- 改进的绘制部分 ---
-    for plugin_index, (plugin_name, commands) in enumerate(plugins_data):
-        # 绘制插件标题栏
-        header_y = current_y
-        draw.rectangle((0, header_y, IMG_WIDTH, header_y + SECTION_HEADER_HEIGHT), fill=COLOR_SECTION_HEADER_BG)
-        marker_x = PADDING + SECTION_MARKER_PADDING
-        marker_y = header_y + SECTION_MARKER_PADDING
-        draw.rectangle((marker_x, marker_y, marker_x + SECTION_MARKER_SIZE, marker_y + SECTION_MARKER_SIZE),
-                       fill=COLOR_ACCENT)
-        _bbox_p, (p_w, p_h) = get_text_metrics(plugin_name, font_plugin_header, draw)
-        title_py = header_y + (SECTION_HEADER_HEIGHT - p_h) // 2
-        draw.text((PADDING + SECTION_TITLE_LEFT_MARGIN, title_py), plugin_name, font=font_plugin_header,
-                  fill=COLOR_TEXT_PLUGIN)
-        current_y += SECTION_HEADER_HEIGHT + SECTION_SPACING_BELOW_HEADER
+    def _load_logo(self) -> None:
+        try:
+            logo_img = Image.open(self.LOGO_PATH).convert("RGBA")
+            img_data = np.array(logo_img)
+            r, g, b, a = img_data.T
+            white_areas = (
+                (r >= self.COLOR_LOGO_BG_REMOVE[0] - self.LOGO_BG_TOLERANCE)
+                & (g >= self.COLOR_LOGO_BG_REMOVE[1] - self.LOGO_BG_TOLERANCE)
+                & (b >= self.COLOR_LOGO_BG_REMOVE[2] - self.LOGO_BG_TOLERANCE)
+                & (a > 128)
+            )
+            img_data[..., -1][white_areas.T] = 0
+            logo_transparent = Image.fromarray(img_data)
+            ow, oh = logo_transparent.size
+            new_w = int(self.LOGO_TARGET_HEIGHT * ow / oh)
+            self.resized_logo = logo_transparent.resize(
+                (new_w, self.LOGO_TARGET_HEIGHT), Image.Resampling.LANCZOS
+            )
+        except Exception as e:
+            logger.warning(f"加载或处理 Logo 时出错: {e}")
+            self.resized_logo = None
 
-        if commands:
-            # 修改：优先处理长描述卡片和预计算所有卡片宽高
-            cards_info = []
-            max_cards_per_row = 4
-            std_card_width = (available_width_for_cards - (max_cards_per_row - 1) * CARD_SPACING) / max_cards_per_row
-            std_card_inner_width = max(50, std_card_width - CARD_PADDING_X * 2)
-            double_card_width = min(available_width_for_cards, std_card_width * 2 + CARD_SPACING)
-            double_card_inner_width = max(50, double_card_width - CARD_PADDING_X * 2)
+    # ---------------- 文本解析 ----------------
+    @staticmethod
+    def _parse_single_command_list(text_list) -> List[Tuple[str, str | None]]:
+        commands = []
+        lines = (
+            text_list.strip().splitlines()
+            if isinstance(text_list, str)
+            else [ln for ln in text_list if ln.strip()]
+        )
 
-            # 预计算每个卡片的尺寸和类型
-            for i, (cmd, desc) in enumerate(commands):
-                # 只取描述的第一行
-                if desc and '\n' in desc:
-                    desc = desc.split('\n')[0].strip()
+        for line in lines:
+            raw = line
+            stripped = line.strip()
+            if not stripped or (stripped.startswith("[") and stripped.endswith("]")):
+                continue
+            if (raw.startswith("  ") or raw.startswith("\t")) and commands:
+                cmd, desc = commands[-1]
+                commands[-1] = (cmd, (desc or "") + stripped)
+                continue
 
-                is_tall = (desc is not None and len(desc) > TALL_CARD_DESC_LENGTH_THRESHOLD)
-                if is_tall:
-                    card_w = double_card_width
-                    card_inner_w = double_card_inner_width
-                    size_category = "double"
-                else:
-                    card_w = std_card_width
-                    card_inner_w = std_card_inner_width
-                    size_category = "standard"
+            # 新命令解析
+            parts = None
+            for sep in (" : ", " # ", "#", ":"):
+                if sep in stripped:
+                    parts = stripped.split(sep, 1)
+                    break
+            if parts and len(parts) == 2:
+                cmd = (
+                    parts[0][2:].strip()
+                    if parts[0].startswith("- ")
+                    else parts[0].strip()
+                )
+                desc = parts[1].strip()
+            else:
+                cmd = stripped[2:].strip() if stripped.startswith("- ") else stripped
+                desc = None
+            commands.append((cmd, desc))
 
-                content_h = calculate_card_content_height(cmd, desc, card_inner_w, draw)
-                card_h = content_h + CARD_PADDING_Y * 2
+        # 只保留描述第一行
+        return [(c, (d.splitlines()[0].strip() if d else None)) for c, d in commands]
 
-                # 增加描述长度属性
-                desc_length = len(desc) if desc else 0
+    def _parse_plugin_commands_sorted_grouped(
+        self, plugin_dict: Dict[str, Any]
+    ) -> List[Tuple[str, List[Tuple[str, str | None]]]]:
+        # 是否显示内置指令
+        if getattr(self.config, "show_builtin_cmds", True):
+            built_in_list = self._parse_single_command_list(self.BUILT_IN_COMMANDS_TEXT)
+            built_in_plugin = ("内置指令", built_in_list) if built_in_list else None
+        else:
+            built_in_plugin = None
 
-                cards_info.append({
-                    "index": i,
-                    "cmd": cmd,
-                    "desc": desc,
-                    "desc_length": desc_length,
-                    "width": card_w,
-                    "height": card_h,
-                    "inner_width": card_inner_w,
-                    "category": size_category
-                })
+        large_plugins, small_plugins = [], []
+        for name, cmds_raw in plugin_dict.items():
+            if name == "内置指令" or not cmds_raw:
+                continue
+             # 如果在黑名单里，跳过
+            if name in getattr(self.config, "plugin_blacklist", []):
+                continue
+            cmds = self._parse_single_command_list(cmds_raw)
+            if not cmds:
+                continue
+            (small_plugins if len(cmds) == 1 else large_plugins).append((name, cmds))
 
-                # 分离双宽卡片和标准卡片
-            double_cards = [card for card in cards_info if card["category"] == "double"]
-            standard_cards = [card for card in cards_info if card["category"] == "standard"]
+        large_plugins.sort(key=lambda x: len(x[1]), reverse=True)
 
-            # 按描述长度排序标准卡片（描述少的在前面）
-            standard_cards.sort(key=lambda x: x["desc_length"])
+        grouped_small_plugin = None
+        if small_plugins:
+            all_small = [c for _, cmds in small_plugins for c in cmds]
+            if all_small:
+                grouped_small_plugin = ("简易指令", all_small)
+                logger.info(f"-> 创建 '简易指令' ({len(all_small)} 条)")
 
-            # 先处理双宽卡片 - 每个独占一行
-            for card in double_cards:
-                cmd = card["cmd"]
-                desc = card["desc"]
-                card_w = card["width"]
-                card_h = card["height"]
-                card_inner_w = card["inner_width"]
+        result = []
+        if built_in_plugin:
+            result.append(built_in_plugin)
+        result.extend(large_plugins)
+        if grouped_small_plugin:
+            result.append(grouped_small_plugin)
 
-                # 绘制双宽卡片 - 每个独占一行
-                card_x = PADDING
-                card_rect = (card_x, current_y, card_x + card_w, current_y + card_h)
-                draw_rounded_rectangle(draw, card_rect, CARD_CORNER_RADIUS,
-                                       fill=COLOR_CARD_BACKGROUND, outline=COLOR_CARD_OUTLINE, width=1)
+        # 添加自定义命令
+        custom_list = []
+        if getattr(self.config, "custom_cmds", None):
+            custom_list = self._parse_single_command_list(self.config.custom_cmds)
+            if custom_list:
+                result.append(("自定义命令", custom_list))
+                logger.info(f"-> 创建 '自定义命令' ({len(custom_list)} 条)")
 
-                # 绘制卡片内容
-                content_x = card_x + CARD_PADDING_X
-                content_y = current_y + CARD_PADDING_Y
-                draw.text((content_x, content_y), cmd, font=font_command, fill=COLOR_TEXT_COMMAND)
+        return result
 
-                if desc:
-                    # 计算描述文本位置
-                    cmd_bbox, (cmd_w, cmd_h) = get_text_metrics(cmd, font_command, draw)
-                    desc_y = content_y + cmd_h + CARD_INTERNAL_SPACE
+    # ---------------- 绘图辅助 ----------------
+    @staticmethod
+    def _draw_gradient(
+        draw,
+        width: int,
+        height: int,
+        start: Tuple[int, int, int],
+        end: Tuple[int, int, int],
+    ):
+        for y in range(height):
+            r = int(start[0] + (end[0] - start[0]) * y / height)
+            g = int(start[1] + (end[1] - start[1]) * y / height)
+            b = int(start[2] + (end[2] - start[2]) * y / height)
+            draw.line([(0, y), (width, y)], fill=(r, g, b))
 
-                    # 文本自动换行
-                    avg_char_width_bbox, (avg_w, avg_h) = get_text_metrics("A", font_desc, draw)
-                    avg_char_width = avg_w if avg_w > 0 else font_desc.size * 0.6
-                    wrap_width_chars = max(10, int(card_inner_w / avg_char_width * 0.95))
+    def _get_text_metrics(
+        self, text: str, font: ImageFont.FreeTypeFont, draw
+    ) -> Tuple[Tuple[int, int, int, int], Tuple[int, int]]:
+        if not text:
+            return (0, 0, 0, 0), (0, 0)
+        try:
+            bbox = draw.textbbox((0, 0), text, font=font)
+            w, h = bbox[2] - bbox[0], bbox[3] - bbox[1]
+            return bbox, (w, h)
+        except AttributeError:
+            w = draw.textlength(text, font=font)
+            h = (
+                sum(font.getmetrics())
+                if sum(font.getmetrics()) > 0
+                else font.size * 1.2
+            )
+            return (0, 0, int(w), int(h)), (int(w), int(h))
+        except Exception:
+            est_w = len(text) * font.size * 0.6
+            est_h = font.size * 1.2
+            return (0, 0, max(1, int(est_w)), max(1, int(est_h))), (
+                max(1, int(est_w)),
+                max(1, int(est_h)),
+            )
 
-                    # 确保只取第一行
-                    if '\n' in desc:
-                        desc = desc.split('\n')[0].strip()
+    def _draw_rounded_rectangle(
+        self, draw, xy, radius, fill=None, outline=None, width=1
+    ):
+        x1, y1, x2, y2 = xy
+        if x1 >= x2 or y1 >= y2:
+            return
+        radius = min(radius, (x2 - x1) // 2, (y2 - y1) // 2)
+        if fill:
+            draw.rectangle((x1 + radius, y1, x2 - radius, y2), fill=fill)
+            draw.rectangle((x1, y1 + radius, x2, y2 - radius), fill=fill)
+            draw.pieslice(
+                (x1, y1, x1 + 2 * radius, y1 + 2 * radius), 180, 270, fill=fill
+            )
+            draw.pieslice(
+                (x2 - 2 * radius, y1, x2, y1 + 2 * radius), 270, 360, fill=fill
+            )
+            draw.pieslice(
+                (x1, y2 - 2 * radius, x1 + 2 * radius, y2), 90, 180, fill=fill
+            )
+            draw.pieslice((x2 - 2 * radius, y2 - 2 * radius, x2, y2), 0, 90, fill=fill)
+        if outline and width > 0:
+            draw.arc(
+                (x1, y1, x1 + 2 * radius, y1 + 2 * radius),
+                180,
+                270,
+                fill=outline,
+                width=width,
+            )
+            draw.arc(
+                (x2 - 2 * radius, y1, x2, y1 + 2 * radius),
+                270,
+                360,
+                fill=outline,
+                width=width,
+            )
+            draw.arc(
+                (x1, y2 - 2 * radius, x1 + 2 * radius, y2),
+                90,
+                180,
+                fill=outline,
+                width=width,
+            )
+            draw.arc(
+                (x2 - 2 * radius, y2 - 2 * radius, x2, y2),
+                0,
+                90,
+                fill=outline,
+                width=width,
+            )
+            draw.line([(x1 + radius, y1), (x2 - radius, y1)], fill=outline, width=width)
+            draw.line([(x1 + radius, y2), (x2 - radius, y2)], fill=outline, width=width)
+            draw.line([(x1, y1 + radius), (x1, y2 - radius)], fill=outline, width=width)
+            draw.line([(x2, y1 + radius), (x2, y2 - radius)], fill=outline, width=width)
 
-                    desc_lines = textwrap.wrap(desc, width=wrap_width_chars,
-                                               replace_whitespace=False,
-                                               drop_whitespace=False,
-                                               break_long_words=True)
+    # ---------------- 卡片布局（每行最多 4 张） ----------------
+    def _layout_cards(
+        self,
+        sections: List[Tuple[str, List[Tuple[str, str | None]]]],
+        draw,
+    ) -> List[Dict]:
+        layout_info = []
+        y_offset = self.TOP_AREA_HEIGHT + self.PADDING
+        max_cols = 4
+        card_spacing = self.CARD_SPACING
+        card_width = (
+            self.IMG_WIDTH - self.PADDING * 2 - card_spacing * (max_cols - 1)
+        ) // max_cols
 
-                    # 绘制描述文本
-                    line_y = desc_y
-                    desc_internal_spacing = 1
-                    for line in desc_lines:
-                        draw.text((content_x, line_y), line, font=font_desc, fill=COLOR_TEXT_DESC)
-                        _bbox_line, (_w_line, line_h) = get_text_metrics(line, font_desc, draw)
-                        line_y += line_h + desc_internal_spacing
+        for section_name, cmds in sections:
+            # Section Header
+            layout_info.append({"type": "header", "name": section_name, "y": y_offset})
+            y_offset += self.SECTION_HEADER_HEIGHT + self.SECTION_SPACING_BELOW_HEADER
 
-                # 更新垂直位置
-                current_y += card_h + CARD_SPACING
+            row_cards = []
+            col_idx = 0
+            max_row_height = 0
 
-            # 处理标准卡片，使用更高效的行填充算法
-            current_row_cards = []
-            current_row_width = 0
-            current_row_start_y = current_y
-            max_height_in_row = 0
+            for cmd, desc in cmds:
+                # 命令文本高度
+                _, (w_cmd, h_cmd) = self._get_text_metrics(cmd, self.font_command, draw)
 
-            for card in standard_cards:
-                cmd = card["cmd"]
-                desc = card["desc"]
-                card_w = card["width"]
-                card_h = card["height"]
-                card_inner_w = card["inner_width"]
+                # 自动换行 desc，每行 12 字符
+                wrapped_desc = textwrap.wrap(desc or "", width=12)
+                bbox = self.font_desc.getbbox("A")
+                line_height = bbox[3] - bbox[1] + self.CARD_INTERNAL_SPACE
 
-                # 检查当前行是否还有足够空间
-                new_width = current_row_width + card_w
-                if current_row_width > 0:  # 如果不是行的第一个卡片，需要考虑间距
-                    new_width += CARD_SPACING
+                # 卡片总高度
+                h_desc_total = len(wrapped_desc) * line_height if wrapped_desc else 0
+                card_h = max(
+                    self.CARD_PADDING_TOP
+                    + h_cmd
+                    + self.NAME_DESC_SPACING
+                    + h_desc_total
+                    + self.CARD_PADDING_BOTTOM,
+                    35,
+                )
 
-                # 如果这个卡片放不下，开始新的一行
-                if new_width > available_width_for_cards and current_row_cards:
-                    # 绘制当前行的所有卡片
-                    card_x = PADDING
-                    for row_card in current_row_cards:
-                        row_cmd = row_card["cmd"]
-                        row_desc = row_card["desc"]
-                        row_card_w = row_card["width"]
-                        row_card_h = row_card["height"]
-                        row_card_inner_w = row_card["inner_width"]
+                row_cards.append(
+                    {
+                        "type": "card",
+                        "name": cmd,
+                        "desc": desc,
+                        "height": card_h,
+                    }
+                )
+                max_row_height = max(max_row_height, card_h)
+                col_idx += 1
 
-                        # 垂直居中对齐行中的卡片
-                        y_offset = (max_height_in_row - row_card_h) // 2
-                        card_y = current_row_start_y + y_offset
+                # 达到一行或最后一张
+                if col_idx == max_cols:
+                    for i, card in enumerate(row_cards):
+                        card["x"] = self.PADDING + i * (card_width + card_spacing)
+                        card["y"] = y_offset
+                        card["width"] = card_width
+                    layout_info.extend(row_cards)
+                    y_offset += max_row_height + card_spacing
+                    row_cards = []
+                    col_idx = 0
+                    max_row_height = 0
 
-                        # 绘制卡片背景
-                        card_rect = (card_x, card_y, card_x + row_card_w, card_y + row_card_h)
-                        draw_rounded_rectangle(draw, card_rect, CARD_CORNER_RADIUS,
-                                               fill=COLOR_CARD_BACKGROUND, outline=COLOR_CARD_OUTLINE, width=1)
+            # 剩余不足一行的卡片
+            if row_cards:
+                for i, card in enumerate(row_cards):
+                    card["x"] = self.PADDING + i * (card_width + card_spacing)
+                    card["y"] = y_offset
+                    card["width"] = card_width
+                layout_info.extend(row_cards)
+                y_offset += max_row_height + card_spacing
 
-                        # 绘制卡片内容
-                        content_x = card_x + CARD_PADDING_X
-                        content_y = card_y + CARD_PADDING_Y
-                        draw.text((content_x, content_y), row_cmd, font=font_command, fill=COLOR_TEXT_COMMAND)
+            y_offset += self.SECTION_SPACING_AFTER_CARDS
+        return layout_info
 
-                        if row_desc:
-                            # 计算描述文本位置
-                            cmd_bbox, (cmd_w, cmd_h) = get_text_metrics(row_cmd, font_command, draw)
-                            desc_y = content_y + cmd_h + CARD_INTERNAL_SPACE
+    # ---------------- 绘制卡片（每行多张支持） ----------------
+    def _draw_cards(self, img: Image.Image, layout_info: List[Dict]) -> None:
+        draw = ImageDraw.Draw(img)
+        for item in layout_info:
+            if item["type"] == "header":
+                draw.rectangle(
+                    (
+                        0,
+                        item["y"],
+                        self.IMG_WIDTH,
+                        item["y"] + self.SECTION_HEADER_HEIGHT,
+                    ),
+                    fill=self.COLOR_SECTION_HEADER_BG,
+                )
+                draw.ellipse(
+                    (
+                        self.SECTION_MARKER_PADDING,
+                        item["y"] + self.SECTION_MARKER_PADDING,
+                        self.SECTION_MARKER_PADDING + self.SECTION_MARKER_SIZE,
+                        item["y"]
+                        + self.SECTION_MARKER_PADDING
+                        + self.SECTION_MARKER_SIZE,
+                    ),
+                    fill=self.COLOR_ACCENT,
+                )
+                draw.text(
+                    (
+                        self.SECTION_TITLE_LEFT_MARGIN,
+                        item["y"] + self.SECTION_MARKER_PADDING,
+                    ),
+                    item["name"],
+                    font=self.font_plugin_header,
+                    fill=self.COLOR_TEXT_HEADER,
+                )
+            elif item["type"] == "card":
+                x0, y0 = item["x"], item["y"]
+                x1, y1 = x0 + item["width"], y0 + item["height"]
+                self._draw_rounded_rectangle(
+                    draw,
+                    (x0, y0, x1, y1),
+                    radius=self.CARD_CORNER_RADIUS,
+                    fill=self.COLOR_CARD_BACKGROUND,
+                    outline=self.COLOR_CARD_OUTLINE,
+                    width=1,
+                )
+                # name
+                draw.text(
+                    (x0 + self.CARD_PADDING_X, y0 + self.CARD_PADDING_TOP),
+                    item["name"],
+                    font=self.font_command,
+                    fill=self.COLOR_TEXT_COMMAND,
+                )
+                if item.get("desc"):
+                    wrapped_desc = textwrap.wrap(item["desc"], width=12)
+                    bbox_cmd = self.font_command.getbbox(item["name"])
+                    y_start = (
+                        y0
+                        + self.CARD_INTERNAL_SPACE
+                        + (bbox_cmd[3] - bbox_cmd[1])
+                        + self.NAME_DESC_SPACING
+                    )
+                    line_height = (
+                        self.font_desc.getbbox("A")[3]
+                        - self.font_desc.getbbox("A")[1]
+                        + self.CARD_INTERNAL_SPACE
+                    )
+                    for i, line in enumerate(wrapped_desc):
+                        draw.text(
+                            (x0 + self.CARD_PADDING_X, y_start + i * line_height),
+                            line,
+                            font=self.font_desc,
+                            fill=self.COLOR_TEXT_DESC,
+                        )
 
-                            # 文本自动换行
-                            avg_char_width_bbox, (avg_w, avg_h) = get_text_metrics("A", font_desc, draw)
-                            avg_char_width = avg_w if avg_w > 0 else font_desc.size * 0.6
-                            wrap_width_chars = max(10, int(row_card_inner_w / avg_char_width * 0.95))
+    # ---------------- 主函数 ----------------
+    def draw_help_image(self, plugin_commands_dict: Dict[str, Any]) -> bytes:
+        # 解析插件命令
+        sections = self._parse_plugin_commands_sorted_grouped(plugin_commands_dict)
 
-                            # 确保只取第一行
-                            if '\n' in row_desc:
-                                row_desc = row_desc.split('\n')[0].strip()
+        # 初步计算总高度
+        temp_img = Image.new("RGB", (self.IMG_WIDTH, 1000), color=(255, 255, 255))
+        draw = ImageDraw.Draw(temp_img)
+        layout_info = self._layout_cards(sections, draw)
+        total_height = (
+            layout_info[-1]["y"]
+            + (layout_info[-1]["height"] if "height" in layout_info[-1] else 0)
+            + self.FOOTER_HEIGHT
+            + self.PADDING
+        )
 
-                            desc_lines = textwrap.wrap(row_desc, width=wrap_width_chars,
-                                                       replace_whitespace=False,
-                                                       drop_whitespace=False,
-                                                       break_long_words=True)
+        # 创建最终图片
+        img = Image.new("RGB", (self.IMG_WIDTH, total_height), color=(255, 255, 255))
+        draw = ImageDraw.Draw(img)
+        # 渐变背景
+        self._draw_gradient(
+            draw,
+            self.IMG_WIDTH,
+            total_height,
+            self.COLOR_BACKGROUND_START,
+            self.COLOR_BACKGROUND_END,
+        )
 
-                            # 绘制描述文本
-                            line_y = desc_y
-                            desc_internal_spacing = 1
-                            for line in desc_lines:
-                                draw.text((content_x, line_y), line, font=font_desc, fill=COLOR_TEXT_DESC)
-                                _bbox_line, (_w_line, line_h) = get_text_metrics(line, font_desc, draw)
-                                line_y += line_h + desc_internal_spacing
+        # 绘制logo
+        if self.resized_logo:
+            img.paste(
+                self.resized_logo, (self.PADDING, self.PADDING), self.resized_logo
+            )
+            title_text = "AstrBot 命令帮助"
+            subtitle_text = "可用插件及指令列表"
+            logo_w, logo_h = self.resized_logo.size
+            x_start = self.PADDING + logo_w + 15
+            y_start_title = self.PADDING
+            y_start_subtitle = (
+                self.PADDING
+                + self.font_title.getbbox(title_text)[3]
+                - self.font_title.getbbox(title_text)[1]
+                + 5
+            )
+            draw.text(
+                (x_start, y_start_title),
+                title_text,
+                font=self.font_title,
+                fill=self.COLOR_TEXT_HEADER,
+            )
+            draw.text(
+                (x_start, y_start_subtitle),
+                subtitle_text,
+                font=self.font_subtitle,
+                fill=self.COLOR_TEXT_SUBTITLE,
+            )
 
-                        # 更新水平位置
-                        card_x += row_card_w + CARD_SPACING
+        # 绘制卡片
+        self._draw_cards(img, layout_info)
 
-                    # 更新垂直位置到下一行开始
-                    current_y = current_row_start_y + max_height_in_row + CARD_SPACING
-                    current_row_start_y = current_y
-                    current_row_cards = []
-                    current_row_width = 0
-                    max_height_in_row = 0
-
-                # 添加当前卡片到行
-                current_row_cards.append(card)
-                if current_row_width > 0:  # 如果不是行的第一个卡片，添加间距
-                    current_row_width += CARD_SPACING
-                current_row_width += card_w
-                max_height_in_row = max(max_height_in_row, card_h)
-
-            # 绘制最后一行的卡片（如果有）
-            if current_row_cards:
-                card_x = PADDING
-                for row_card in current_row_cards:
-                    row_cmd = row_card["cmd"]
-                    row_desc = row_card["desc"]
-                    row_card_w = row_card["width"]
-                    row_card_h = row_card["height"]
-                    row_card_inner_w = row_card["inner_width"]
-
-                    # 垂直居中对齐行中的卡片
-                    y_offset = (max_height_in_row - row_card_h) // 2
-                    card_y = current_row_start_y + y_offset
-
-                    # 绘制卡片背景
-                    card_rect = (card_x, card_y, card_x + row_card_w, card_y + row_card_h)
-                    draw_rounded_rectangle(draw, card_rect, CARD_CORNER_RADIUS,
-                                           fill=COLOR_CARD_BACKGROUND, outline=COLOR_CARD_OUTLINE, width=1)
-
-                    # 绘制卡片内容
-                    content_x = card_x + CARD_PADDING_X
-                    content_y = card_y + CARD_PADDING_Y
-                    draw.text((content_x, content_y), row_cmd, font=font_command, fill=COLOR_TEXT_COMMAND)
-
-                    if row_desc:
-                        # 计算描述文本位置
-                        cmd_bbox, (cmd_w, cmd_h) = get_text_metrics(row_cmd, font_command, draw)
-                        desc_y = content_y + cmd_h + CARD_INTERNAL_SPACE
-
-                        # 文本自动换行
-                        avg_char_width_bbox, (avg_w, avg_h) = get_text_metrics("A", font_desc, draw)
-                        avg_char_width = avg_w if avg_w > 0 else font_desc.size * 0.6
-                        wrap_width_chars = max(10, int(row_card_inner_w / avg_char_width * 0.95))
-
-                        # 确保只取第一行
-                        if '\n' in row_desc:
-                            row_desc = row_desc.split('\n')[0].strip()
-
-                        desc_lines = textwrap.wrap(row_desc, width=wrap_width_chars,
-                                                   replace_whitespace=False,
-                                                   drop_whitespace=False,
-                                                   break_long_words=True)
-
-                        # 绘制描述文本
-                        line_y = desc_y
-                        desc_internal_spacing = 1
-                        for line in desc_lines:
-                            draw.text((content_x, line_y), line, font=font_desc, fill=COLOR_TEXT_DESC)
-                            _bbox_line, (_w_line, line_h) = get_text_metrics(line, font_desc, draw)
-                            line_y += line_h + desc_internal_spacing
-
-                    # 更新水平位置
-                    card_x += row_card_w + CARD_SPACING
-
-                # 更新垂直位置
-                current_y = current_row_start_y + max_height_in_row + CARD_SPACING
-
-            # 为下一个章节添加间距
-        current_y += SECTION_SPACING_AFTER_CARDS - CARD_SPACING  # 减去多余的卡片间距
-
-    # --- Draw Footer ---
-    footer_y = total_height - FOOTER_HEIGHT
-    draw.rectangle((0, footer_y, IMG_WIDTH, total_height), fill=(245, 247, 250))
-    footer_text = "Power by AstrBot & Created By astrbot_plugin_help"
-    _bbox_footer, (footer_w, footer_h) = get_text_metrics(footer_text, font_footer, draw)
-    footer_text_x = (IMG_WIDTH - footer_w) // 2  # 水平居中
-    footer_text_y = footer_y + (FOOTER_HEIGHT - footer_h) // 2  # 垂直居中
-    # 绘制居中文本
-    draw.text((footer_text_x, footer_text_y), footer_text, font=font_footer, fill=COLOR_TEXT_FOOTER)
-
-        # --- Save Image ---
-    # print("正在保存图片...")
-    img.save("astrbot_cmds_help.png", format="PNG", optimize=True)
-    logger.info(f"已生成命令帮助图片 (尺寸: {img.size[0]}x{img.size[1]})")
+        # 底部版权
+        footer_text = f"AstrBot v{self.config.version}"
+        bbox = draw.textbbox((0, 0), footer_text, font=self.font_footer)
+        fw = bbox[2] - bbox[0]
+        fh = bbox[3] - bbox[1]
+        draw.text(
+            (
+                self.IMG_WIDTH - fw - self.PADDING,
+                total_height - self.FOOTER_HEIGHT + (self.FOOTER_HEIGHT - fh) // 2,
+            ),
+            footer_text,
+            font=self.font_footer,
+            fill=self.COLOR_TEXT_FOOTER,
+        )
+        # 转成 bytes
+        with io.BytesIO() as output:
+            img.save(output, format="PNG", optimize=True)
+            return output.getvalue()

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,5 +1,5 @@
-name: plugin_help # 这是你的插件的唯一识别名。
+name: astrbot_plugin_help # 这是你的插件的唯一识别名。
 desc: 查看所有命令，包括插件，返回一张帮助图片 # 插件简短描述
-version: v1.1.2 # 插件版本号。格式：v1.1.1 或者 v1.1
+version: v1.1.3 # 插件版本号。格式：v1.1.1 或者 v1.1
 author: tinker # 作者
 repo: https://github.com/tinkerbellqwq/astrbot_plugin_help # 插件的仓库地址


### PR DESCRIPTION
- 重构了绘图代码，封装成绘图类，从9百多行精简到500多行，并且不改变出图效果，旨在增加可读性，方便维护
- 增加内置指令是否显示开关
- 增加自定义命令配置，方便补充由消息监听器或正则形成的命令
- 增加插件黑名单，屏蔽自己不想显示帮助的插件

## Sourcery 总结

将帮助图片生成重构为专用的 AstrBotHelpDrawer 类，为内置命令、自定义命令和插件黑名单添加可配置性，并更新插件以使用新的绘图器并以字节形式返回图片。更新版本、元数据、schema 和文档。

新特性：
- 添加配置开关 (show_builtin_cmds) 以显示或隐藏内置命令
- 在配置中引入 custom_cmds 用于用户定义的命令列表
- 在配置中实现 plugin_blacklist 以从帮助图片中排除不需要的插件
- 将帮助命令切换为通过 Image.fromBytes 生成并以字节数据形式返回图片

改进：
- 将 draw.py 重构为 AstrBotHelpDrawer 类，整合绘图辅助函数并将代码量减少约 200 行
- 更新插件初始化以注入 AstrBotConfig 并利用新的绘图器类进行图片生成

文档：
- 更新 README，包含新的安装步骤、使用别名和示例输出
- 更新 metadata.yaml 中的插件名称和版本
- 添加 _conf_schema.json 以定义配置 schema

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the help image generation into a dedicated AstrBotHelpDrawer class, add configurability for built-in commands, custom commands, and plugin blacklist, and update the plugin to use the new drawer and return images as bytes. Bump version, update metadata, schema, and docs.

New Features:
- Add config toggle (show_builtin_cmds) to show or hide built-in commands
- Introduce custom_cmds in config for user-defined command lists
- Implement plugin_blacklist in config to exclude unwanted plugins from the help image
- Switch help command to generate and return the image as byte data via Image.fromBytes

Enhancements:
- Refactor draw.py into AstrBotHelpDrawer class, consolidating drawing helpers and reducing code size by ~200 lines
- Update plugin initialization to inject AstrBotConfig and leverage the new drawer class for image generation

Documentation:
- Update README with new installation steps, usage aliases, and sample output
- Bump plugin name and version in metadata.yaml
- Add _conf_schema.json to define configuration schema

</details>