### PR TITLE
新增权限命令区分。

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -2,11 +2,17 @@
     "show_builtin_cmds": {
         "description": "显示内置插件命令",
         "type": "bool",
+        "default": true
+    },
+    "show_all_cmds": {
+        "description": "显示所有插件命令",
+        "hint": "开启后将会显示管理员可用的插件命令。仅需要时开启。",
+        "type": "bool",
         "default": false
     },
     "custom_cmds": {
         "description": "自定义的额外命令",
-        "hint": "一些通过正则或者监听器形成的命令无法检测，可通过自定义方式补充，格式为“命令: 一段描述”，分隔符为英文逗号或#",
+        "hint": "一些通过正则或者监听器形成的命令无法检测，可通过自定义方式补充，格式为“命令:一段描述”",
         "type": "list",
         "default": []
     },
@@ -15,5 +21,15 @@
         "hint": "填写插件名称(区分大小写)，如：astrbot_plugin_help，黑名单里的插件不显示帮助",
         "type": "list",
         "default": []
+    },
+    "plugin_display_names": {
+        "description": "插件显示名称",
+        "hint": "填写插件名称和显示名称，格式为“插件名称:显示名称”，分隔符为英文逗号",
+        "type": "list",
+        "default": [
+            "builtin_commands:内置指令",
+            "daily_60s_news:每日60秒新闻",
+            "astrbot_plugin_zanwo:QQ资料卡点赞"
+        ]
     }
 }

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,5 +1,10 @@
 name: astrbot_plugin_help # 这是你的插件的唯一识别名。
+display_name: 更好的帮助 # 插件的显示名称，可以包含空格和特殊字符
 desc: 查看所有命令，包括插件，返回一张帮助图片 # 插件简短描述
-version: v1.1.3 # 插件版本号。格式：v1.1.1 或者 v1.1
+version: v1.2.0 # 插件版本号。格式：v1.1.1 或者 v1.1
 author: tinker # 作者
 repo: https://github.com/tinkerbellqwq/astrbot_plugin_help # 插件的仓库地址
+astrbot_version: ">=4.17.0"
+support_platforms:
+  - aiocqhttp
+


### PR DESCRIPTION
## 由 Sourcery 提供的摘要

增强插件帮助系统，为所有活动插件生成更丰富、与权限相关的命令列表和帮助图片。

新功能：
- 在构建帮助命令列表时包含命令权限等级，并可根据配置选择性隐藏仅限管理员的命令。
- 在生成帮助输出时，支持可配置的插件显示名称以及内置命令的可见性。
- 扩展帮助命令的触发别名，加入更多语言变体。

改进：
- 优化帮助图片生成流程，使其接受结构化的命令元数据，而不是硬编码或纯文本命令列表。
- 从绘制器中移除硬编码的内置命令文本，改为依赖动态收集的插件命令。
- 更新插件元数据，加入面向用户的显示名称、更严格的 AstrBot 版本要求，以及支持的平台声明。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhance the plugin help system to generate a richer, permission-aware command list and help image for all active plugins.

New Features:
- Include command permission levels when building the help command list, optionally hiding admin-only commands based on configuration.
- Support configurable plugin display names and built-in command visibility when generating the help output.
- Extend the help command trigger aliases to include additional language variants.

Enhancements:
- Refine the help image generation pipeline to accept structured command metadata instead of hardcoded or plain-text command lists.
- Remove hardcoded built-in command text from the drawer and rely on dynamically collected plugin commands.
- Update plugin metadata with a user-facing display name, stricter AstrBot version requirement, and supported platform declarations.

</details>