### PR TITLE
更新至1.2.7版本

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ _✨ [astrbot](https://github.com/AstrBotDevs/AstrBot) 帮助插件 ✨_
 
 </div>
 
-# 更好的帮助
+# astrbot_plugin_help
 
 ## ⚠️⚠️⚠️ 旧版更新请注意 ⚠️⚠️⚠️
 - 尽可能卸载后重新从插件市场安装本插件（卸载旧版时请勾选 `同时删除插件配置文件`）

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 ![:astrbot_plugin_help](https://count.getloli.com/@:astrbot_plugin_help?theme=minecraft)
 
-# astrbot_plugin_help
+# 更好的帮助
 
 _✨ [astrbot](https://github.com/AstrBotDevs/AstrBot) 帮助插件 ✨_  
 
@@ -14,7 +14,10 @@ _✨ [astrbot](https://github.com/AstrBotDevs/AstrBot) 帮助插件 ✨_
 
 </div>
 
-# astrbot_plugin_help
+# 更好的帮助
+
+## ⚠️⚠️⚠️ 旧版更新请注意 ⚠️⚠️⚠️
+- 尽可能卸载后重新从插件市场安装本插件（卸载旧版时请勾选 `同时删除插件配置文件`）
 
 ## 🤝 介绍
 

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -2,11 +2,17 @@
     "show_builtin_cmds": {
         "description": "显示内置插件命令",
         "type": "bool",
+        "default": true
+    },
+    "show_all_cmds": {
+        "description": "显示所有插件命令",
+        "hint": "开启后将会显示管理员可用的插件命令。仅需要时开启。",
+        "type": "bool",
         "default": false
     },
     "custom_cmds": {
         "description": "自定义的额外命令",
-        "hint": "一些通过正则或者监听器形成的命令无法检测，可通过自定义方式补充，格式为“命令: 一段描述”，分隔符为英文逗号或#",
+        "hint": "一些通过正则或者监听器形成的命令无法检测，可通过自定义方式补充，格式为“命令:一段描述”",
         "type": "list",
         "default": []
     },
@@ -15,5 +21,15 @@
         "hint": "填写插件名称(区分大小写)，如：astrbot_plugin_help，黑名单里的插件不显示帮助",
         "type": "list",
         "default": []
+    },
+    "plugin_display_names": {
+        "description": "插件显示名称",
+        "hint": "填写插件名称和显示名称，格式为“插件名称:显示名称”，分隔符为英文逗号",
+        "type": "list",
+        "default": [
+            "builtin_commands:内置指令",
+            "daily_60s_news:每日60秒新闻",
+            "astrbot_plugin_zanwo:QQ资料卡点赞"
+        ]
     }
 }

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -1,12 +1,13 @@
 {
     "show_builtin_cmds": {
         "description": "显示内置插件命令",
+        "hint": "显示AstrBot原生内置的命令",
         "type": "bool",
         "default": true
     },
     "show_all_cmds": {
         "description": "显示所有插件命令",
-        "hint": "开启后将会显示管理员可用的插件命令。仅需要时开启。",
+        "hint": "开启后将会显示管理员可用的插件命令，仅需要时开启。可在<Dashboard-插件-管理行为>中修改每条命令的权限。",
         "type": "bool",
         "default": false
     },
@@ -16,14 +17,8 @@
         "type": "list",
         "default": []
     },
-    "plugin_blacklist": {
-        "description": "插件黑名单",
-        "hint": "填写插件名称(区分大小写)，如：astrbot_plugin_help，黑名单里的插件不显示帮助",
-        "type": "list",
-        "default": []
-    },
     "plugin_display_names": {
-        "description": "插件显示名称",
+        "description": "插件显示名称（当部分插件不存在外显名称时使用）",
         "hint": "填写插件名称和显示名称，格式为“插件名称:显示名称”，分隔符为英文逗号",
         "type": "list",
         "default": [
@@ -31,5 +26,27 @@
             "daily_60s_news:每日60秒新闻",
             "astrbot_plugin_zanwo:QQ资料卡点赞"
         ]
+    },
+    "plugin_blacklist": {
+        "description": "插件黑名单",
+        "hint": "填写插件名称(区分大小写)，如：每日60秒新闻，黑名单里的插件不显示帮助",
+        "type": "list",
+        "default": []
+    },
+    "title_help": {
+        "description": "帮助菜单标题",
+        "type": "string",
+        "default": "AstrBot 命令帮助"
+    },
+    "title_desc": {
+        "description": "帮助菜单简介",
+        "type": "string",
+        "default": "可用插件及指令列表"
+    },
+    "logo_enable": {
+        "description": "启用帮助菜单logo",
+        "hint": "可以在插件目录替换astrbot_logo.jpg为自定义的logo。",
+        "type": "bool",
+        "default": true
     }
 }

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,7 +1,7 @@
 name: astrbot_plugin_help # 这是你的插件的唯一识别名。
 display_name: 更好的帮助 # 插件的显示名称，可以包含空格和特殊字符
 desc: 查看所有命令，包括插件，返回一张帮助图片 # 插件简短描述
-version: v1.2.0 # 插件版本号。格式：v1.1.1 或者 v1.1
+version: v1.2.7 # 插件版本号。格式：v1.1.1 或者 v1.1
 author: tinker # 作者
 repo: https://github.com/tinkerbellqwq/astrbot_plugin_help # 插件的仓库地址
 astrbot_version: ">=4.17.0"

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,5 +1,10 @@
 name: astrbot_plugin_help # 这是你的插件的唯一识别名。
+display_name: 更好的帮助 # 插件的显示名称，可以包含空格和特殊字符
 desc: 查看所有命令，包括插件，返回一张帮助图片 # 插件简短描述
-version: v1.1.3 # 插件版本号。格式：v1.1.1 或者 v1.1
+version: v1.2.0 # 插件版本号。格式：v1.1.1 或者 v1.1
 author: tinker # 作者
 repo: https://github.com/tinkerbellqwq/astrbot_plugin_help # 插件的仓库地址
+astrbot_version: ">=4.17.0"
+support_platforms:
+  - aiocqhttp
+


### PR DESCRIPTION
实现了权限分类显示（设置里自定义显示开关）、可自定义菜单标题简介、水印logo修复

## Summary by Sourcery

更新帮助图片和指令收集逻辑，以支持可配置标题、基于权限的指令可见性，以及基于元数据的插件品牌展示，面向 1.2.7 版本发布。

New Features:
- 允许通过配置自定义帮助图片的标题和副标题文本。
- 按插件显示名称对插件指令进行分组展示，并支持通过配置进行可选重映射。
- 在收集的指令元数据中包含指令权限等级（admin/member/everyone），并可根据设置选择性隐藏仅限管理员的指令。
- 新增通过配置开关控制是否显示内置指令的支持。
- 为帮助指令触发词增加繁体中文别名支持。
- 从 `metadata.yaml` 中读取插件显示名称和版本，用于页脚品牌展示和兼容性检查。

Enhancements:
- 调整帮助图片布局，以在有无 logo 的场景下都能正常工作，改进页眉留白和渲染效果。
- 修改帮助图片页脚内容，改为显示插件的显示名称和版本，而非核心 AstrBot 版本。
- 改进指令解析逻辑，在支持插件提供的纯文本指令定义的同时，也支持结构化的指令列表。
- 明确并扩展插件元数据和 README 文档，包括新增从旧版本升级的用户注意事项。

Documentation:
- 在 README 中将插件名称改为其显示名称，并为从旧版本迁移过来的用户添加升级说明。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update the help image and command collection to support configurable titles, permission-based command visibility, and metadata-driven plugin branding for the 1.2.7 release.

New Features:
- Allow customizing the help image title and subtitle text via configuration.
- Show plugin commands grouped by plugin display names with optional remapping from configuration.
- Include command permission levels (admin/member/everyone) in the collected command metadata and optionally hide admin-only commands based on settings.
- Add support for toggling the display of built-in commands through configuration.
- Support traditional Chinese aliases for the help command trigger.
- Read plugin display name and version from metadata.yaml for footer branding and compatibility checks.

Enhancements:
- Adjust the help image layout to work both with and without a logo, improving header spacing and rendering.
- Switch the help image footer to show the plugin’s display name and version instead of the core AstrBot version.
- Improve command parsing to accept structured command lists from plugins in addition to plain text definitions.
- Clarify and expand plugin metadata and README, including a new user notice for upgrading from older versions.

Documentation:
- Rename the plugin in the README to its display name and add upgrade notes for users coming from older versions.

</details>