### PR TITLE
fix: 将 total_height 强制转为整数以避免 Image.new 的 TypeError

### DIFF
--- a/draw.py
+++ b/draw.py
@@ -508,7 +508,8 @@ class AstrBotHelpDrawer:
             + self.FOOTER_HEIGHT
             + self.PADDING
         )
-
+        total_height = int(total_height)
+        
         # 创建最终图片
         img = Image.new("RGB", (self.IMG_WIDTH, total_height), color=(255, 255, 255))
         draw = ImageDraw.Draw(img)


### PR DESCRIPTION
问题
图片生成时 total_height 可能为浮点数，导致 PIL 报错 #9 

修复
添加 int() 转换，确保传入 Image.new 的尺寸为整数。

## Summary by Sourcery

Bug Fixes:
- 在将计算得到的 `total_height` 传递给 `Image.new` 之前，将其转换为整数，以防止在高度为浮点数时出现 `TypeError`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Convert computed total_height to an integer before passing it to Image.new to prevent TypeError when the height is a float.

</details>